### PR TITLE
test(ci): adapt to the fact that dependabot PR have no access to secrets

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,9 +11,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      # some tests need credentials when hitting github endpoints - see src/infra/github/__testTools__/secrets.ts.sample
-      TEST_CREDENTIALS: ${{ secrets.TEST_CREDENTIALS }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -50,8 +47,16 @@ jobs:
       - name: Typescript linting
         run: npm run lint
 
-      - name: Unit tests
-        run: npm run test
+      - name: Unit tests (no secrets)
+        # dependabot has no access to secrets - cf https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        run: npm run test:no-secrets
+
+      - name: Unit tests (need secrets)
+        if: ${{ env.TEST_CREDENTIALS }} != ""
+        run: npm run test:need-secrets
+        env:
+          # some tests need credentials when hitting github endpoints - see src/infra/github/__testTools__/secrets.ts.sample
+          TEST_CREDENTIALS: ${{ secrets.TEST_CREDENTIALS }}
 
   build:
     needs: test

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "start": "HTTP_PORT=9903 node dist/index.js",
     "start:dev": "HTTP_PORT=9903 concurrently \"nodemon\" \"nodemon -x tsoa spec-and-routes\"",
     "test": "jest --testTimeout=15000",
+    "test:no-secrets": "jest --testTimeout=15000 -t='^((?!(#needs-secrets)).)*$' --silent",
+    "test:need-secrets": "jest --testTimeout=15000 -t=#needs-secrets --silent",
     "ts:check": "tsc --noEmit --noErrorTruncation ",
     "tsoa:gen": "tsoa spec-and-routes"
   },

--- a/src/infra/EnvVars.ts
+++ b/src/infra/EnvVars.ts
@@ -34,6 +34,14 @@ export class EnvVars {
     return (JSON.parse(strValue) as unknown) as T;
   }
 
+  public static getOptionalJson<T>(envVarName: string, defaultValue: T): T {
+    const strValue = this.getOptionalString(envVarName, '');
+    if (!strValue) {
+      return defaultValue;
+    }
+    return (JSON.parse(strValue) as unknown) as T;
+  }
+
   public static getOptionalBool(envVarName: string, defaultValue: boolean = false): boolean {
     const value = process.env[envVarName];
     if (value === undefined) {

--- a/src/infra/codemagic/__testTools__/TestCredentials.ts
+++ b/src/infra/codemagic/__testTools__/TestCredentials.ts
@@ -7,7 +7,7 @@ try {
   realSecrets = require('./secrets').SECRETS;
   // eslint-disable-next-line no-empty
 } catch {
-  realSecrets = EnvVars.getJson<Partial<Secrets>>('TEST_CREDENTIALS');
+  realSecrets = EnvVars.getOptionalJson<Partial<Secrets>>('TEST_CREDENTIALS', {});
 }
 
 const DEFAULT_SECRETS: Secrets = {

--- a/src/infra/codemagic/__tests__/AppRepository.spec.ts
+++ b/src/infra/codemagic/__tests__/AppRepository.spec.ts
@@ -11,7 +11,7 @@ describe('AppRepository', () => {
   });
 
   describe('listForToken', () => {
-    test('should return all apps when using token', async () => {
+    test('should return all apps when using token #needs-secrets', async () => {
       const sut = new AppRepository(clientFactory);
 
       const actual = await sut.listForToken(testCredentials.PRIVATE_API_KEY);

--- a/src/infra/codemagic/__tests__/WorkflowRunRepository.spec.ts
+++ b/src/infra/codemagic/__tests__/WorkflowRunRepository.spec.ts
@@ -10,8 +10,8 @@ describe('WorkflowRunRepository', () => {
   });
   describe('getLatestRunsForWorkflow', () => {
     test('should retrieve runs of known workflow (yaml / app build)', async () => {
-      const appId = '5fc6539af7698e06abe1becd';
-      const workflowId = 'foundations-build';
+      const appId = '5fc6539af7698e06abe1becf';
+      const workflowId = 'mindset-build';
       const sut = new WorkflowRunRepository(clientFactory);
 
       const actual = await sut.getLatestRunsForWorkflow(
@@ -26,11 +26,11 @@ describe('WorkflowRunRepository', () => {
 
       expect([...actual.entries()]).not.toHaveLength(0);
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const runsOfBranchDevelop = actual.get('develop')!;
-      expect(runsOfBranchDevelop).toBeDefined();
-      expect(runsOfBranchDevelop).not.toHaveLength(0);
+      const runsOfBranchMaster = actual.get('master')!;
+      expect(runsOfBranchMaster).toBeDefined();
+      expect(runsOfBranchMaster).not.toHaveLength(0);
 
-      const actualRun = runsOfBranchDevelop[0];
+      const actualRun = runsOfBranchMaster[0];
       expect(actualRun).toEqual<WorkflowRun>({
         id: expect.stringContaining(''),
         startTime: expect.any(Date),
@@ -82,8 +82,8 @@ describe('WorkflowRunRepository', () => {
     });
 
     test('should sort builds from older to newer', async () => {
-      const appId = '5fc6539af7698e06abe1becd';
-      const workflowId = 'foundations-build';
+      const appId = '5fc6539af7698e06abe1becf';
+      const workflowId = 'mindset-build';
       const sut = new WorkflowRunRepository(clientFactory);
 
       const actual = await sut.getLatestRunsForWorkflow(
@@ -98,9 +98,9 @@ describe('WorkflowRunRepository', () => {
 
       expect([...actual.entries()]).not.toHaveLength(0);
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const runsOfBranchDevelop = actual.get('develop')!;
-      const oldestRun = runsOfBranchDevelop[0];
-      const secondOldestRun = runsOfBranchDevelop[1];
+      const runsOfBranchMaster = actual.get('master')!;
+      const oldestRun = runsOfBranchMaster[0];
+      const secondOldestRun = runsOfBranchMaster[1];
       // oldest first
       expect(oldestRun.startTime.getTime()).toBeLessThan(secondOldestRun.startTime.getTime());
     });

--- a/src/infra/codemagic/__tests__/WorkflowRunRepository.spec.ts
+++ b/src/infra/codemagic/__tests__/WorkflowRunRepository.spec.ts
@@ -9,7 +9,7 @@ describe('WorkflowRunRepository', () => {
     buildInfo: {},
   });
   describe('getLatestRunsForWorkflow', () => {
-    test('should retrieve runs of known workflow (yaml / app build)', async () => {
+    test('should retrieve runs of known workflow (yaml / app build) #needs-secrets', async () => {
       const appId = '5fc6539af7698e06abe1becf';
       const workflowId = 'mindset-build';
       const sut = new WorkflowRunRepository(clientFactory);
@@ -44,7 +44,7 @@ describe('WorkflowRunRepository', () => {
       });
     });
 
-    test('should retrieve runs of known workflow (yaml / pull request)', async () => {
+    test('should retrieve runs of known workflow (yaml / pull request) #needs-secrets', async () => {
       const appId = '5fc6539af7698e06abe1becd';
       const workflowId = 'pull-request';
       const sut = new WorkflowRunRepository(clientFactory);
@@ -81,7 +81,7 @@ describe('WorkflowRunRepository', () => {
       });
     });
 
-    test('should sort builds from older to newer', async () => {
+    test('should sort builds from older to newer #needs-secrets', async () => {
       const appId = '5fc6539af7698e06abe1becf';
       const workflowId = 'mindset-build';
       const sut = new WorkflowRunRepository(clientFactory);
@@ -105,7 +105,7 @@ describe('WorkflowRunRepository', () => {
       expect(oldestRun.startTime.getTime()).toBeLessThan(secondOldestRun.startTime.getTime());
     });
 
-    test('should apply maxAgeInDays', async () => {
+    test('should apply maxAgeInDays #needs-secrets', async () => {
       const appId = '5fc6539af7698e06abe1becf';
       const workflowId = 'mindset-build';
       const sut = new WorkflowRunRepository(clientFactory);
@@ -129,7 +129,7 @@ describe('WorkflowRunRepository', () => {
       expect(oldestRun.startTime.getTime()).toBeGreaterThan(nDaysAgo.getTime());
     });
 
-    test('should apply maxRunsPerBranch in repo with lots of activity', async () => {
+    test('should apply maxRunsPerBranch in repo with lots of activity #needs-secrets', async () => {
       const appId = '5fc6539af7698e06abe1becd';
       const workflowId = 'foundations-build';
       const sut = new WorkflowRunRepository(clientFactory);


### PR DESCRIPTION
as of https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/